### PR TITLE
Make getWMIObject(..) return a list of maps with *all* enumerated objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /TestBugPowerShell/nbproject/private/
 /.project
 /.classpath
+.idea/
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -3,10 +3,10 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.profesorfalken</groupId>
     <artifactId>WMI4Java</artifactId>
-    <version>1.4.2</version>
+    <version>1.4.3-SNAPSHOT</version>
     <packaging>jar</packaging>
-    
-    
+
+
     <name>WMI4Java</name>
     <description>API to query WMI from Java</description>
     <url>https://github.com/profesorfalken/WMI4Java</url>
@@ -18,7 +18,7 @@
             <distribution>repo</distribution>
         </license>
     </licenses>
-    
+
     <developers>
         <developer>
             <name>Javier Garcia Alonso</name>
@@ -27,11 +27,11 @@
             <organizationUrl>http://www.profesorfalken.com</organizationUrl>
         </developer>
     </developers>
-    
+
     <scm>
         <url>https://github.com/profesorfalken/WMI4Java.git</url>
     </scm>
-    
+
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
@@ -42,7 +42,7 @@
             <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
         </repository>
     </distributionManagement>
-    
+
     <profiles>
         <profile>
             <id>release-profile</id>
@@ -107,7 +107,7 @@
             </build>
         </profile>
     </profiles>
-    
+
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,8 @@
     </dependencies>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>1.5</maven.compiler.source>
-        <maven.compiler.target>1.5</maven.compiler.target>
-        <sonar.java.source>1.5</sonar.java.source>
+        <maven.compiler.source>1.6</maven.compiler.source>
+        <maven.compiler.target>1.6</maven.compiler.target>
+        <sonar.java.source>1.6</sonar.java.source>
     </properties>
 </project>

--- a/src/main/java/com/profesorfalken/wmi4java/WMI4Java.java
+++ b/src/main/java/com/profesorfalken/wmi4java/WMI4Java.java
@@ -15,14 +15,7 @@
  */
 package com.profesorfalken.wmi4java;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -229,7 +222,7 @@ public class WMI4Java {
      * @return map with the key and the value of all the properties of the
      * object
      */
-    public Map<String, String> getWMIObject(WMIClass wmiClass) {
+    public List<Map<String, String>> getWMIObject(WMIClass wmiClass) {
         return getWMIObject(wmiClass.getName());
     }
 
@@ -240,30 +233,34 @@ public class WMI4Java {
      * @return map with the key and the value of all the properties of the
      * object
      */
-    public Map<String, String> getWMIObject(String wmiClass) {
-        Map<String, String> foundWMIClassProperties = new HashMap<String, String>();
+    public List<Map<String, String>> getWMIObject(String wmiClass) {
+        List<Map<String, String>> foundWMIClassProperties = new LinkedList<Map<String, String>>();
         try {
             String rawData;
             if (this.properties != null || this.filters != null) {
-                rawData = getWMIStub().queryObject(wmiClass, this.properties, this.filters, 
+                rawData = getWMIStub().queryObject(wmiClass, this.properties, this.filters,
                         this.namespace, this.computerName);
             } else {
                 rawData = getWMIStub().listObject(wmiClass, this.namespace, this.computerName);
-            }            
+            }
 
-            String[] dataStringLines = rawData.split(NEWLINE_REGEX);
-
-            for (final String line : dataStringLines) {
-                if (!line.isEmpty()) {
-                    String[] entry = line.split(":");
-                    if (entry != null && entry.length == 2) {
-                        foundWMIClassProperties.put(entry[0].trim(), entry[1].trim());
+            String[] dataStringObjects = rawData.split(NEWLINE_REGEX + NEWLINE_REGEX);
+            for (String dataStringObject : dataStringObjects) {
+                String[] dataStringLines = dataStringObject.split(NEWLINE_REGEX);
+                Map<String, String> objectProperties = new HashMap<String, String>();
+                for (final String line : dataStringLines) {
+                    if (!line.isEmpty()) {
+                        String[] entry = line.split(":");
+                        if (entry.length == 2) {
+                            objectProperties.put(entry[0].trim(), entry[1].trim());
+                        }
                     }
                 }
+                foundWMIClassProperties.add(objectProperties);
             }
         } catch (WMIException ex) {
             Logger.getLogger(WMI4Java.class.getName()).log(Level.SEVERE, GENERIC_ERROR_MSG, ex);
-            foundWMIClassProperties = Collections.emptyMap();
+            foundWMIClassProperties = Collections.emptyList();
         }
         return foundWMIClassProperties;
     }
@@ -288,7 +285,7 @@ public class WMI4Java {
         String rawData;
         try {
             if (this.properties != null || this.filters != null) {
-                rawData = getWMIStub().queryObject(wmiClass, this.properties, this.filters, 
+                rawData = getWMIStub().queryObject(wmiClass, this.properties, this.filters,
                         this.namespace, this.computerName);
             } else {
                 rawData = getWMIStub().listObject(wmiClass, this.namespace, this.computerName);

--- a/src/main/java/com/profesorfalken/wmi4java/WMI4Java.java
+++ b/src/main/java/com/profesorfalken/wmi4java/WMI4Java.java
@@ -219,8 +219,7 @@ public class WMI4Java {
      * Query all the object data for an specific class
      *
      * @param wmiClass Enum that contains the most used classes (root/cimv2)
-     * @return map with the key and the value of all the properties of the
-     * object
+     * @return list of maps, each with key/value pairs for all object properties
      */
     public List<Map<String, String>> getWMIObject(WMIClass wmiClass) {
         return getWMIObject(wmiClass.getName());
@@ -230,8 +229,7 @@ public class WMI4Java {
      * Query all the object data for an specific class
      *
      * @param wmiClass string with the name of the class to query
-     * @return map with the key and the value of all the properties of the
-     * object
+     * @return list of maps, each with key/value pairs for all object properties
      */
     public List<Map<String, String>> getWMIObject(String wmiClass) {
         List<Map<String, String>> foundWMIClassProperties = new LinkedList<Map<String, String>>();

--- a/src/test/java/com/profesorfalken/wmi4java/MainGetInfo.java
+++ b/src/test/java/com/profesorfalken/wmi4java/MainGetInfo.java
@@ -163,7 +163,7 @@ public class MainGetInfo {
                 long initTime = System.currentTimeMillis();
                 System.out.println("==========Class " + wmiClass + " ==============");
 
-                Map<String, String> wmiObjectProperties = wmi4java.VBSEngine().VBSEngine().getWMIObject(wmiClass);
+                Map<String, String> wmiObjectProperties = wmi4java.VBSEngine().VBSEngine().getWMIObject(wmiClass).get(0);
 
                 Set<Map.Entry<String, String>> properties = wmiObjectProperties.entrySet();
                 for (Map.Entry<String, String> property : properties) {

--- a/src/test/java/com/profesorfalken/wmi4java/WMI4JavaTest.java
+++ b/src/test/java/com/profesorfalken/wmi4java/WMI4JavaTest.java
@@ -153,7 +153,7 @@ public class WMI4JavaTest {
         if (OSDetector.isWindows()) {
             WMI4Java wmi4java = WMI4Java.get();
 
-            Map<String, String> wmiObjectProperties = wmi4java.getWMIObject("Win32_BaseBoard");
+            Map<String, String> wmiObjectProperties = wmi4java.getWMIObject("Win32_BaseBoard").get(0);
 
             assertTrue("Returned WMI object list is empty! ",
                     !wmiObjectProperties.isEmpty());
@@ -162,7 +162,7 @@ public class WMI4JavaTest {
             assertNotNull("Manufacturer property should not be null ",
                     wmiObjectProperties.get("Manufacturer"));
 
-            Map<String, String> wmiObjectPropertiesVB = wmi4java.VBSEngine().getWMIObject("Win32_BaseBoard");
+            Map<String, String> wmiObjectPropertiesVB = wmi4java.VBSEngine().getWMIObject("Win32_BaseBoard").get(0);
 
             assertTrue("Returned WMI object list is empty! ",
                     !wmiObjectPropertiesVB.isEmpty());


### PR DESCRIPTION
Solves #3.

Now I can do something like this (using Java Streams API) ...
```java
package de.scrum_master.app;

import com.profesorfalken.wmi4java.WMI4Java;
import com.profesorfalken.wmi4java.WMIClass;

import java.util.Arrays;
import java.util.stream.Collectors;

public class Printer {
    public static void main(String[] args) {
        System.out.println(
            WMI4Java
                .get()
                .properties(Arrays.asList("Name", "WorkOffline"))
                .filters(Arrays.asList("$_.WorkOffline -eq 0"))
                .getWMIObject(WMIClass.WIN32_PRINTER)
                .stream()
                .map(properties -> properties.get("Name"))
                .sorted()
                .collect(Collectors.toList())
        );
    }
}
```

... which yields the following output on my machine:

```
[Fax, FinePrint, FreePDF, Microsoft Print to PDF, Microsoft XPS Document Writer, Send To OneNote 2016, WEB.DE Club SmartFax]
```