### PR TITLE
Fix: Stderr- and stdout-Encoding are not respected #10

### DIFF
--- a/src/main/java/com/profesorfalken/wmi4java/WMIVBScript.java
+++ b/src/main/java/com/profesorfalken/wmi4java/WMIVBScript.java
@@ -51,9 +51,9 @@ class WMIVBScript implements WMIStub {
             writer.close();
 
             Process process = Runtime.getRuntime().exec(
-                    new String[]{"cmd.exe", "/C", "cscript.exe", "/NoLogo", tmpFile.getAbsolutePath()});
+                    new String[]{"cmd.exe", "/C", "cscript.exe", "/U", "/NoLogo", tmpFile.getAbsolutePath()});
             BufferedReader processOutput
-                    = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                    = new BufferedReader(new InputStreamReader(process.getInputStream(), "UTF-16LE"));
             String line;
             while ((line = processOutput.readLine()) != null) {
                 if (!line.isEmpty()) {
@@ -63,7 +63,7 @@ class WMIVBScript implements WMIStub {
 
             if (scriptResponse.isEmpty()) {
                 errorOutput
-                        = new BufferedReader(new InputStreamReader(process.getInputStream()));
+                        = new BufferedReader(new InputStreamReader(process.getInputStream(), "UTF-16LE"));
                 String errorResponse = "";
                 while ((line = errorOutput.readLine()) != null) {
                     if (!line.isEmpty()) {


### PR DESCRIPTION
Hello!
I use an implementation based on VBScript because VBScript exists on any windows machines.
I had a problem that WMI output has question marks (?????) instead of cyrilic characters in WMI output.
I fixed it by adding // U parameter to cscript.exe invocation.
https://technet.microsoft.com/ru-ru/library/ff920171(v=ws.11).aspx