### PR TITLE
Split WMI output line into at most two parts

### DIFF
--- a/src/main/java/com/profesorfalken/wmi4java/WMI4Java.java
+++ b/src/main/java/com/profesorfalken/wmi4java/WMI4Java.java
@@ -281,8 +281,10 @@ public class WMI4Java {
 
 			for (final String line : dataStringLines) {
 				if (!line.isEmpty()) {
-					String[] entry = line.split(":");
-					if (entry != null && entry.length == 2) {
+					// Limit to 2 split entries as WMI property names may not contain colons
+					// See: https://docs.microsoft.com/en-us/windows/win32/wmisdk/wmi-classes#naming-conventions-for-wmi-classes-and-properties
+					String[] entry = line.split(":", 2);
+					if (entry.length == 2) {
 						foundWMIClassProperties.put(entry[0].trim(), entry[1].trim());
 					}
 				}
@@ -341,7 +343,9 @@ public class WMI4Java {
 				Map<String, String> objectProperties = new HashMap<String, String>();
 				for (final String line : dataStringLines) {
 					if (!line.isEmpty()) {
-						String[] entry = line.split(":");
+						// Limit to 2 split entries as WMI property names may not contain colons
+						// See: https://docs.microsoft.com/en-us/windows/win32/wmisdk/wmi-classes#naming-conventions-for-wmi-classes-and-properties
+						String[] entry = line.split(":", 2);
 						if (entry.length == 2) {
 							objectProperties.put(entry[0].trim(), entry[1].trim());
 						}


### PR DESCRIPTION
The library had trouble parsing command line output like `MACAddress: AB:CD:EF:GH:IJ` as it expected only a single colon to be present. I've fixed this by splitting only at the first occurrence of a colon.

I've also removed an unneeded null-check as `split` always return non-null values.